### PR TITLE
Feature/language specific character validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,90 @@ puts unihan.contains_zh_cn?("這個text不包含簡體字")  # => false
 
 このライブラリは、テキストの言語を完全に正確に判定することを保証するものではありません。
 特に、短いテキストや複数の言語が混在するテキストの場合、判定が難しい場合があります。
+
+## =========================
+
+# UnihanLang
+
+UnihanLang is a Ruby library for identifying text language (Traditional Chinese, Simplified Chinese) and performing various checks on Chinese characters.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'unihan_lang'
+```
+
+And then execute:
+
+```sh
+bundle install
+```
+
+Or install it yourself as:
+
+```sh
+gem install unihan_lang
+```
+
+## Usage
+
+```ruby
+require 'unihan_lang'
+
+unihan = UnihanLang::Unihan.new
+
+# Language determination
+puts unihan.determine_language("這是繁體中文")      # => "ZH_TW"
+puts unihan.determine_language("这是简体中文")      # => "ZH_CN"
+
+# Check if text is Traditional Chinese
+puts unihan.zh_tw?("這是繁體中文")  # => true
+puts unihan.zh_tw?("这不是繁体中文")  # => false
+
+# Check if text is Simplified Chinese
+puts unihan.zh_cn?("这是简体中文")  # => true
+puts unihan.zh_cn?("這不是簡體中文")  # => false
+
+# Check if text contains Chinese characters
+puts unihan.contains_chinese?("This text contains 中文")  # => true
+puts unihan.contains_chinese?("This text has no Chinese")  # => false
+
+# Extract Chinese characters from text
+puts unihan.extract_chinese_characters("This text contains 中文").join  # => "中文"
+
+# Check if text consists only of Traditional Chinese characters
+puts unihan.only_zh_tw?("繁體")  # => true
+puts unihan.only_zh_tw?("繁體简体")  # => false
+
+# Check if text consists only of Simplified Chinese characters
+puts unihan.only_zh_cn?("简体")  # => true
+puts unihan.only_zh_cn?("简体繁體")  # => false
+
+# Check if text contains Traditional Chinese characters
+puts unihan.contains_zh_tw?("這個text包含繁體字")  # => true
+puts unihan.contains_zh_tw?("这个text不包含繁体字")  # => false
+
+# Check if text contains Simplified Chinese characters
+puts unihan.contains_zh_cn?("这个text包含简体字")  # => true
+puts unihan.contains_zh_cn?("這個text不包含簡體字")  # => false
+```
+
+## Features
+
+- `determine_language(text)`: Determines the language of the text ("ZH_TW", "ZH_CN", "JA", "Unknown").
+- `zh_tw?(text)`: Checks if the text is in Traditional Chinese.
+- `zh_cn?(text)`: Checks if the text is in Simplified Chinese.
+- `contains_chinese?(text)`: Checks if the text contains Chinese characters.
+- `extract_chinese_characters(text)`: Extracts Chinese characters from the text.
+- `only_zh_tw?(text)`: Checks if the text consists only of Traditional Chinese characters.
+- `only_zh_cn?(text)`: Checks if the text consists only of Simplified Chinese characters.
+- `contains_zh_tw?(text)`: Checks if the text contains Traditional Chinese characters.
+- `contains_zh_cn?(text)`: Checks if the text contains Simplified Chinese characters.
+
+## Note
+
+This library does not guarantee 100% accuracy in language identification.
+Particularly for short texts or texts containing multiple languages, determination may be challenging.
+The distinction between Traditional and Simplified Chinese is based on the Unihan database.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # UnihanLang
 
-UnihanLang は、テキストの言語（日本語、繁体字中国語、簡体字中国語）を識別するための Ruby ライブラリです。
+UnihanLang は、テキストの言語（繁体字中国語、簡体字中国語）を識別し、中国語の文字に関する様々な判定を行うための Ruby ライブラリです。
 
 ## インストール
 
@@ -49,7 +49,35 @@ puts unihan.contains_chinese?("This text has no Chinese")  # => false
 
 # テキストから中国語の文字を抽出
 puts unihan.extract_chinese_characters("This text contains 中文").join  # => "中文"
+
+# 繁体字のみで構成されているかの判定
+puts unihan.only_zh_tw?("繁體")  # => true
+puts unihan.only_zh_tw?("繁體简体")  # => false
+
+# 簡体字のみで構成されているかの判定
+puts unihan.only_zh_cn?("简体")  # => true
+puts unihan.only_zh_cn?("简体繁體")  # => false
+
+# 繁体字を含むかどうかの判定
+puts unihan.contains_zh_tw?("這個text包含繁體字")  # => true
+puts unihan.contains_zh_tw?("这个text不包含繁体字")  # => false
+
+# 簡体字を含むかどうかの判定
+puts unihan.contains_zh_cn?("这个text包含简体字")  # => true
+puts unihan.contains_zh_cn?("這個text不包含簡體字")  # => false
 ```
+
+## 機能説明
+
+- `determine_language(text)`: テキストの言語を判定します（"ZH_TW", "ZH_CN", "Unknown"）。
+- `zh_tw?(text)`: テキストが繁体字中国語かどうかを判定します。
+- `zh_cn?(text)`: テキストが簡体字中国語かどうかを判定します。
+- `contains_chinese?(text)`: テキストに中国語の文字が含まれているかを判定します。
+- `extract_chinese_characters(text)`: テキストから中国語の文字を抽出します。
+- `only_zh_tw?(text)`: テキストが繁体字のみで構成されているかを判定します。
+- `only_zh_cn?(text)`: テキストが簡体字のみで構成されているかを判定します。
+- `contains_zh_tw?(text)`: テキストに繁体字が含まれているかを判定します。
+- `contains_zh_cn?(text)`: テキストに簡体字が含まれているかを判定します。
 
 ## 注意事項
 

--- a/lib/unihan_lang.rb
+++ b/lib/unihan_lang.rb
@@ -17,6 +17,22 @@ module UnihanLang
       language_ratio(text) == :cn
     end
 
+    def only_zh_tw?(text)
+      text.chars.all? { |char| @chinese_processor.only_zh_tw?(char) }
+    end
+
+    def only_zh_cn?(text)
+      text.chars.all? { |char| @chinese_processor.only_zh_cn?(char) }
+    end
+
+    def contains_zh_tw?(text)
+      text.chars.any? { |char| @chinese_processor.only_zh_tw?(char) }
+    end
+
+    def contains_zh_cn?(text)
+      text.chars.any? { |char| @chinese_processor.only_zh_cn?(char) }
+    end
+
     def contains_chinese?(text)
       text.chars.any? { |char| @chinese_processor.chinese_character?(char) }
     end
@@ -27,7 +43,6 @@ module UnihanLang
 
     def determine_language(text)
       case language_ratio(text)
-      when :ja then "JA"
       when :tw then "ZH_TW"
       when :cn then "ZH_CN"
       else "Unknown"
@@ -38,13 +53,13 @@ module UnihanLang
 
     # テキストの言語比率を計算し、最も可能性の高い言語を返す
     def language_ratio(text)
-      tw_chars = text.chars.count { |char| @chinese_processor.zh_tw?(char) }
-      cn_chars = text.chars.count { |char| @chinese_processor.zh_cn?(char) }
+      only_tw_chars = text.chars.count { |char| @chinese_processor.only_zh_tw?(char) }
+      only_cn_chars = text.chars.count { |char| @chinese_processor.only_zh_cn?(char) }
       chinese_chars = text.chars.count { |char| @chinese_processor.chinese?(char) }
 
       return :unknown unless chinese_chars == text.length
-      return :tw if tw_chars > cn_chars
-      return :cn if cn_chars >= tw_chars
+      return :tw if only_tw_chars > only_cn_chars
+      return :cn if only_cn_chars >= only_tw_chars
 
       :unknown
     end

--- a/lib/unihan_lang/chinese_processor.rb
+++ b/lib/unihan_lang/chinese_processor.rb
@@ -19,6 +19,14 @@ module UnihanLang
       @zh_cn.include?(char) || @common.include?(char)
     end
 
+    def only_zh_tw?(char)
+      @zh_tw.include?(char) && !@common.include?(char)
+    end
+
+    def only_zh_cn?(char)
+      @zh_cn.include?(char)
+    end
+
     def chinese?(char)
       zh_tw?(char) || zh_cn?(char) || cjk?(char)
     end

--- a/spec/unihan_lang_spec.rb
+++ b/spec/unihan_lang_spec.rb
@@ -58,4 +58,57 @@ RSpec.describe UnihanLang::Unihan do
       expect(unihan.determine_language('This is English')).to eq('Unknown')
     end
   end
+
+  # 新しい機能のテスト
+  describe '#only_zh_tw?' do
+    it '繁体字のみで構成されたテキストに対してtrueを返す' do
+      expect(unihan.only_zh_tw?('繁體')).to be true
+    end
+
+    it '簡体字を含むテキストに対してfalseを返す' do
+      expect(unihan.only_zh_tw?('繁體简体')).to be false
+    end
+
+    it '共通の字を含むテキストに対してfalseを返す' do
+      expect(unihan.only_zh_tw?('繁體中文')).to be false
+    end
+  end
+
+  describe '#only_zh_cn?' do
+    it '簡体字のみで構成されたテキストに対してtrueを返す' do
+      expect(unihan.only_zh_cn?('简体')).to be true
+    end
+
+    it '繁体字を含むテキストに対してfalseを返す' do
+      expect(unihan.only_zh_cn?('简体繁體')).to be false
+    end
+
+    it '共通の字を含むテキストに対してfalseを返す' do
+      expect(unihan.only_zh_cn?('简体中文')).to be false
+    end
+  end
+
+  describe '#contains_zh_tw?' do
+    it '繁体字を含むテキストに対してtrueを返す' do
+      expect(unihan.contains_zh_tw?('這個text包含繁體字')).to be true
+    end
+
+    it '繁体字を含まないテキストに対してfalseを返す' do
+      expect(unihan.contains_zh_tw?('这个text不包含简体字')).to be false
+    end
+
+    it '共通の漢字のみを含むテキストに対してfalseを返す' do
+      expect(unihan.contains_zh_tw?('中文')).to be false
+    end
+  end
+
+  describe '#contains_zh_cn?' do
+    it '簡体字を含むテキストに対してtrueを返す' do
+      expect(unihan.contains_zh_cn?('这个text包含简体字')).to be true
+    end
+
+    it '簡体字を含まないテキストに対してfalseを返す' do
+      expect(unihan.contains_zh_cn?('這個text不包含簡體字')).to be false
+    end
+  end
 end


### PR DESCRIPTION
# 繁体字・簡体字の判定機能の追加

## 概要
このPRでは、UnihanLangに繁体字と簡体字を個別に判定する新機能を追加しています。
これにより、テキストが繁体字または簡体字のみで構成されているか、
またはそれらを含んでいるかを判定できるようになります。

## 追加された機能
- `only_zh_tw?(text)`: テキストが繁体字のみで構成されているかを判定
- `only_zh_cn?(text)`: テキストが簡体字のみで構成されているかを判定
- `contains_zh_tw?(text)`: テキストに繁体字が含まれているかを判定
- `contains_zh_cn?(text)`: テキストに簡体字が含まれているかを判定

## 変更内容
- `Unihan` クラスに新しいメソッドを追加
- `ChineseProcessor` クラスに補助メソッドを追加
- 新機能のテストケースを追加
- README.mdを更新し、新機能の説明と使用例を追加

## テスト
すべての新機能に対するテストを追加し、既存のテストと合わせて全てのテストがパスすることを確認しました。

## ドキュメンテーション
README.mdを更新し、新機能の使用方法と簡単な説明を追加しました。
