### PR TITLE
中国語文字分類の精度向上

### DIFF
--- a/lib/unihan_lang.rb
+++ b/lib/unihan_lang.rb
@@ -2,11 +2,13 @@
 
 require_relative "unihan_lang/version"
 require_relative "unihan_lang/chinese_processor"
+require_relative "unihan_lang/variant_mapping"
 
 module UnihanLang
   class Unihan
     def initialize
       @chinese_processor = ChineseProcessor.new
+      @variant_mapping = VariantMapping.new
     end
 
     def zh_tw?(text)
@@ -49,18 +51,57 @@ module UnihanLang
       end
     end
 
+    def analyze_with_variants(text)
+      chars = text.chars
+      traditional_score = 0
+      simplified_score = 0
+
+      chars.each do |char|
+        if @chinese_processor.chinese_character?(char)
+          if @chinese_processor.only_zh_tw?(char)
+            traditional_score += 2  # 繁体字の重みを増やす
+          elsif @chinese_processor.only_zh_cn?(char)
+            simplified_score += 2  # 簡体字の重みを増やす
+          end
+
+          # 異体字による判定の重みを調整
+          if @variant_mapping.traditional_variants(char).any?
+            traditional_score += 0.5
+          end
+          if @variant_mapping.simplified_variants(char).any?
+            simplified_score += 0.5
+          end
+        end
+      end
+
+      {
+        traditional_score: traditional_score,
+        simplified_score: simplified_score,
+        total_chinese: chars.count { |c| @chinese_processor.chinese_character?(c) }
+      }
+    end
+
+    def determine_language_with_variants(text)
+      scores = analyze_with_variants(text)
+      return "Unknown" if scores[:total_chinese] == 0
+
+      if scores[:traditional_score] > scores[:simplified_score]
+        "ZH_TW"
+      elsif scores[:simplified_score] > scores[:traditional_score]
+        "ZH_CN"
+      else
+        "Unknown"
+      end
+    end
+
     private
 
     # テキストの言語比率を計算し、最も可能性の高い言語を返す
     def language_ratio(text)
-      only_tw_chars = text.chars.count { |char| @chinese_processor.only_zh_tw?(char) }
-      only_cn_chars = text.chars.count { |char| @chinese_processor.only_zh_cn?(char) }
-      chinese_chars = text.chars.count { |char| @chinese_processor.chinese?(char) }
-
-      return :unknown unless chinese_chars == text.length
-      return :tw if only_tw_chars > only_cn_chars
-      return :cn if only_cn_chars >= only_tw_chars
-
+      scores = analyze_with_variants(text)
+      return :unknown if scores[:total_chinese] != text.length
+      return :tw if scores[:traditional_score] > scores[:simplified_score]
+      return :cn if scores[:simplified_score] >= scores[:traditional_score]
       :unknown
     end
   end

--- a/lib/unihan_lang.rb
+++ b/lib/unihan_lang.rb
@@ -57,21 +57,18 @@ module UnihanLang
       simplified_score = 0
 
       chars.each do |char|
-        if @chinese_processor.chinese_character?(char)
-          if @chinese_processor.only_zh_tw?(char)
-            traditional_score += 2  # 繁体字の重みを増やす
-          elsif @chinese_processor.only_zh_cn?(char)
-            simplified_score += 2  # 簡体字の重みを増やす
-          end
+        next unless @chinese_processor.chinese_character?(char)
 
-          # 異体字による判定の重みを調整
-          if @variant_mapping.traditional_variants(char).any?
-            traditional_score += 0.5
-          end
-          if @variant_mapping.simplified_variants(char).any?
-            simplified_score += 0.5
-          end
+        # 繁体字・簡体字の判定
+        if @chinese_processor.only_zh_tw?(char)
+          traditional_score += 2
+        elsif @chinese_processor.only_zh_cn?(char)
+          simplified_score += 2
         end
+
+        # 異体字による判定
+        traditional_score += 0.5 if @variant_mapping.traditional_variants(char).any?
+        simplified_score += 0.5 if @variant_mapping.simplified_variants(char).any?
       end
 
       {

--- a/lib/unihan_lang/chinese_score_analyzer.rb
+++ b/lib/unihan_lang/chinese_score_analyzer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module UnihanLang
+  class ChineseScoreAnalyzer
+    attr_reader :traditional_score, :simplified_score, :total_chinese
+
+    def initialize(text, chinese_processor, variant_mapping)
+      @text = text
+      @chinese_processor = chinese_processor
+      @variant_mapping = variant_mapping
+      @traditional_score = 0
+      @simplified_score = 0
+      analyze
+    end
+
+    def dominant_language
+      return "Unknown" if total_chinese.zero?
+      return "ZH_TW" if traditional_score > simplified_score
+      return "ZH_CN" if simplified_score > traditional_score
+
+      "Unknown"
+    end
+
+    def language_ratio
+      return :unknown if total_chinese != @text.length
+      return :tw if traditional_score > simplified_score
+      return :cn if simplified_score >= traditional_score
+
+      :unknown
+    end
+
+    private
+
+    def analyze
+      @total_chinese = 0
+      @text.chars.each do |char|
+        next unless @chinese_processor.chinese_character?(char)
+
+        @total_chinese += 1
+
+        calculate_character_scores(char)
+      end
+    end
+
+    def calculate_character_scores(char)
+      if @chinese_processor.only_zh_tw?(char)
+        @traditional_score += 2
+      elsif @chinese_processor.only_zh_cn?(char)
+        @simplified_score += 2
+      end
+
+      @traditional_score += 0.5 if @variant_mapping.traditional_variants(char).any?
+      @simplified_score += 0.5 if @variant_mapping.simplified_variants(char).any?
+    end
+  end
+end

--- a/lib/unihan_lang/variant_mapping.rb
+++ b/lib/unihan_lang/variant_mapping.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module UnihanLang
+  class VariantMapping
+    def initialize
+      @traditional_to_simplified = load_variant_mappings
+      @simplified_to_traditional = {}
+      # 簡体字から繁体字へのマッピングを構築
+      @traditional_to_simplified.each do |trad, simps|
+        simps.each do |simp|
+          @simplified_to_traditional[simp] ||= Set.new
+          @simplified_to_traditional[simp] << trad
+        end
+      end
+    end
+
+    def traditional_variants(char)
+      @simplified_to_traditional[char] || Set.new
+    end
+
+    def simplified_variants(char)
+      @traditional_to_simplified[char] || Set.new
+    end
+
+    private
+
+    def load_variant_mappings
+      traditional_to_simplified = {}
+      file_path = File.join(File.dirname(__FILE__), "..", "..", "data", "Unihan_Variants.txt")
+
+      File.foreach(file_path, encoding: "UTF-8") do |line|
+        next if line.start_with?("#") || line.strip.empty?
+
+        fields = line.strip.split("\t")
+        if fields.size >= 3
+          # kTraditionalVariant フィールドの場合のみ処理
+          if fields[1] == "kTraditionalVariant"
+            simp = [fields[0].gsub(/^U\+/, "").hex].pack("U")
+            trad = [fields[2].gsub(/^U\+/, "").hex].pack("U")
+            traditional_to_simplified[trad] ||= Set.new
+            traditional_to_simplified[trad] << simp
+          end
+        end
+      end
+      traditional_to_simplified
+    end
+  end
+end

--- a/lib/unihan_lang/variant_mapping.rb
+++ b/lib/unihan_lang/variant_mapping.rb
@@ -32,14 +32,12 @@ module UnihanLang
         next if line.start_with?("#") || line.strip.empty?
 
         fields = line.strip.split("\t")
-        if fields.size >= 3
-          # kTraditionalVariant フィールドの場合のみ処理
-          if fields[1] == "kTraditionalVariant"
-            simp = [fields[0].gsub(/^U\+/, "").hex].pack("U")
-            trad = [fields[2].gsub(/^U\+/, "").hex].pack("U")
-            traditional_to_simplified[trad] ||= Set.new
-            traditional_to_simplified[trad] << simp
-          end
+        # kTraditionalVariant フィールドの場合のみ処理
+        if fields.size >= 3 && fields[1] == ("kTraditionalVariant")
+          simp = [fields[0].gsub(/^U\+/, "").hex].pack("U")
+          trad = [fields[2].gsub(/^U\+/, "").hex].pack("U")
+          traditional_to_simplified[trad] ||= Set.new
+          traditional_to_simplified[trad] << simp
         end
       end
       traditional_to_simplified

--- a/spec/unihan_lang_spec.rb
+++ b/spec/unihan_lang_spec.rb
@@ -124,4 +124,63 @@ RSpec.describe UnihanLang::Unihan do
       expect(unihan.contains_zh_cn?('這個text不包含簡體字')).to be false
     end
   end
+
+  describe '#determine_language_with_variants' do
+    context '繁体字の判定精度確認' do
+      it '標準的な繁体字のケース' do
+        expect(unihan.determine_language_with_variants('這是繁體中文的測試')).to eq('ZH_TW')
+      end
+
+      it '異体字を含む繁体字のケース' do
+        # 個別の漢字に対する異体字の例
+        # 発 -> 發, 様 -> 樣, 国 -> 國
+        expect(unihan.determine_language_with_variants('發展樣式國家')).to eq('ZH_TW')
+      end
+
+      it '繁体字に特有の表現を含むケース' do
+        # 裡 (裏), 儘 (尽), 甚麼 (什么) など
+        expect(unihan.determine_language_with_variants('他在裡面做甚麼')).to eq('ZH_TW')
+      end
+
+      it '繁体字と簡体字が混在するが、繁体字が優勢なケース' do
+        # 台/臺 (どちらでも使用), 机/機 (混在)
+        expect(unihan.determine_language_with_variants('在台北的機場裡')).to eq('ZH_TW')
+      end
+    end
+
+    context '共通漢字と特殊ケース' do
+      it '共通漢字が多い場合でも繁体字の特徴を正しく判定' do
+        # 中、日、月などの共通漢字が多い文章
+        expect(unihan.determine_language_with_variants('今天的月亮很圓')).to eq('ZH_TW')
+      end
+
+      it '数字や記号が混ざっている場合' do
+        expect(unihan.determine_language_with_variants('2024年的第一個目標：學習繁體字')).to eq('ZH_TW')
+      end
+
+      it '地名や固有名詞を含むケース' do
+        expect(unihan.determine_language_with_variants('在臺灣學習中文')).to eq('ZH_TW')
+      end
+    end
+
+    context '頻出パターンの検証' do
+      it '教育関連の文章' do
+        expect(unihan.determine_language_with_variants('學生們正在學習數學課程')).to eq('ZH_TW')
+      end
+
+      it 'ビジネス用語を含む文章' do
+        expect(unihan.determine_language_with_variants('公司經營與發展策略')).to eq('ZH_TW')
+      end
+
+      it '日常会話の文章' do
+        expect(unihan.determine_language_with_variants('我們今天要去買東西')).to eq('ZH_TW')
+      end
+    end
+
+    context 'エッジケース' do
+      it '極めて短い文章でも正確に判定' do
+        expect(unihan.determine_language_with_variants('臺')).to eq('ZH_TW')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 変更内容
このPRでは、異体字マッピングを作成、スコアリング重みの調整により、中国語文字の分類精度を向上させています。

### 異体字マッピングの改善点
- 簡体字・繁体字間の双方向マッピングを適切に構築
- UnihanデータベースのkTraditionalVariantフィールドを正しく処理
- マッピングデータの整合性を向上

### スコアリングシステムの改善点
- 直接的な文字判定により高い重みを付与し、基本的な判定の信頼性を向上
- 異体字判定の補助的な役割を明確化するため、重みを適切に調整
- 繁体字と簡体字の判定バランスを最適化

## テスト結果
- 繁体字判定のテストケースが正常に通過
- 簡体字判定の精度を維持しながら、繁体字の判定精度を向上

## レビューポイント
- 異体字マッピングの構築ロジックの妥当性
- スコアリング重みの調整バランス
- テストケースの網羅性